### PR TITLE
Ricander

### DIFF
--- a/database/ddl/STR_DSS_Views_Sprint_16.sql
+++ b/database/ddl/STR_DSS_Views_Sprint_16.sql
@@ -29,6 +29,6 @@ left join dss_platform_type dpt on dpt.platform_type = do2.platform_type
 left join dss_user_identity dui on dui.user_guid = do2.upd_user_guid
 left join dss_organization_contact_person docp on docp.contacted_through_organization_id = do2.organization_id and docp.email_message_type = 'Notice of Takedown' and docp.is_primary = true
 left join dss_organization_contact_person docp2 on docp2.contacted_through_organization_id = do2.organization_id and docp2.email_message_type = 'Takedown Request' and docp2.is_primary = true
-left join dss_organization_contact_person docp3 on docp3.contacted_through_organization_id = do2.organization_id and docp3.email_message_type = 'Notice of Takedown' and docp.is_primary != true
+left join dss_organization_contact_person docp3 on docp3.contacted_through_organization_id = do2.organization_id and docp3.email_message_type = 'Notice of Takedown' and docp3.is_primary != true
 left join dss_organization_contact_person docp4 on docp4.contacted_through_organization_id = do2.organization_id and docp4.email_message_type = 'Takedown Request' and docp4.is_primary != true
 where do2.organization_type = 'Platform';

--- a/server/StrDss.Data/Repositories/OrganizationRepository.cs
+++ b/server/StrDss.Data/Repositories/OrganizationRepository.cs
@@ -273,6 +273,11 @@ namespace StrDss.Data.Repositories
 
             await _dbSet.AddAsync(entity);
 
+            CreateContact(entity, EmailMessageTypes.NoticeOfTakedown, dto.PrimaryNoticeOfTakedownContactEmail, true);
+            CreateContact(entity, EmailMessageTypes.NoticeOfTakedown, dto.SecondaryNoticeOfTakedownContactEmail, false);
+            CreateContact(entity, EmailMessageTypes.TakedownRequest, dto.PrimaryTakedownRequestContactEmail, true);
+            CreateContact(entity, EmailMessageTypes.TakedownRequest, dto.SecondaryTakedownRequestContactEmail, false);
+
             return entity;
         }
 
@@ -283,6 +288,11 @@ namespace StrDss.Data.Repositories
                 .FirstAsync(x => x.OrganizationId == dto.OrganizationId);
 
             _mapper.Map(dto, entity);
+
+            UpdateContact(entity, EmailMessageTypes.NoticeOfTakedown, dto.PrimaryNoticeOfTakedownContactEmail, true);
+            UpdateContact(entity, EmailMessageTypes.NoticeOfTakedown, dto.SecondaryNoticeOfTakedownContactEmail, false);
+            UpdateContact(entity, EmailMessageTypes.TakedownRequest, dto.PrimaryTakedownRequestContactEmail, true);
+            UpdateContact(entity, EmailMessageTypes.TakedownRequest, dto.SecondaryTakedownRequestContactEmail, false);
         }
     }
 }

--- a/server/StrDss.Model/OrganizationDtos/PlatformSubCreateDto.cs
+++ b/server/StrDss.Model/OrganizationDtos/PlatformSubCreateDto.cs
@@ -7,5 +7,9 @@
         public long ManagingOrganizationId { get; set; }
         public bool? IsActive { get; set; } = true;
         public DateTime UpdDtm { get; set; }
+        public string? PrimaryNoticeOfTakedownContactEmail { get; set; }
+        public string? PrimaryTakedownRequestContactEmail { get; set; }
+        public string? SecondaryNoticeOfTakedownContactEmail { get; set; }
+        public string? SecondaryTakedownRequestContactEmail { get; set; }
     }
 }

--- a/server/StrDss.Model/OrganizationDtos/PlatformSubUpdateDto.cs
+++ b/server/StrDss.Model/OrganizationDtos/PlatformSubUpdateDto.cs
@@ -5,6 +5,10 @@
         public long OrganizationId { get; set; }
         public string OrganizationNm { get; set; } = null!;
         public long ManagingOrganizationId { get; set; }
+        public string? PrimaryNoticeOfTakedownContactEmail { get; set; }
+        public string? PrimaryTakedownRequestContactEmail { get; set; }
+        public string? SecondaryNoticeOfTakedownContactEmail { get; set; }
+        public string? SecondaryTakedownRequestContactEmail { get; set; }
         public bool? IsActive { get; set; }
         public DateTime UpdDtm { get; set; }
     }


### PR DESCRIPTION
- Added primary and seconary emails to Platform create/update for Subsidaries
- Bug fix in DB platform_vw that was preventing secondary notice of takedown email address from being returned by get platform. 