### PR TITLE
bug/dss-1062-nights-stayed-label-change

### DIFF
--- a/frontend/src/app/features/components/listings-table/listing-details/listing-details.component.html
+++ b/frontend/src/app/features/components/listings-table/listing-details/listing-details.component.html
@@ -177,7 +177,7 @@
                 Listing History (for This Listing ID)
             </div>
             <div class="row night-stayed-row">
-                <span class="label">Night Stayed YTD:</span>
+                <span class="label">Night Stayed (12M):</span>
                 <span class="value">{{listing.nightsBookedYtdQty}}</span>
             </div>
             <div class="row">

--- a/frontend/src/app/features/components/listings-table/listings-table.component.html
+++ b/frontend/src/app/features/components/listings-table/listings-table.component.html
@@ -105,7 +105,7 @@
 
                     <th class="sortable-header" id="nightsStayed_header"
                         [class.sorted]="this.sort && this.sort.prop === 'nightsBookedYtdQty'"
-                        (click)="onSort('nightsBookedYtdQty')">Nights Stayed (YTD)
+                        (click)="onSort('nightsBookedYtdQty')">Nights Stayed (12M)
                         <i class="pi pi-angle-down"
                             *ngIf="this.sort && this.sort.prop === 'nightsBookedYtdQty' && this.sort.dir === 'desc'"></i>
                         <i class="pi pi-angle-up"


### PR DESCRIPTION
Calculation for Nights Stayed was changed from YTD to rolling 12 Months, but label on individual listing page and detailed listing information page still had YTD.  Change was made to change to 12M.