### PR TITLE
Registration Validation Updates

### DIFF
--- a/server/StrDss.Common/Constants.cs
+++ b/server/StrDss.Common/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace StrDss.Common
+﻿using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace StrDss.Common
 {
     public class Constants
     {
@@ -637,5 +639,20 @@
         public const string Pending = "Pending";
         public const string Processed = "Processed";
         public const string Failed = "Failed";
+    }
+
+    public static class RegistrationValidationText
+    {
+        public const string Success = "Success";
+        public const string DataInvalid = "To validate the registration, please provide the registration number or the rental address associated with this listing.";
+        public const string STRAAExempt = "FN reserve land. This address is exempt from the STRAA.";
+        public const string NotSTRAAExempt = "Please verify if this STR offer is not required to be registered.";
+        public const string AddressNotFound = "Address not found.";
+        public const string JurisdictionNotFound = "Jurisdiction not found.";
+        public const string ExemptionStatusNotFound = "Exemption status not found.";
+        public const string StatusNotFound = "Registration validation Api did not return a registration status.";
+        public const string ValidationException = "Registration validation Api threw an undhandled exception.";
+        public const string ValidationException404 = "Registration validation Api return a status of 404 (Permit not found).";
+        public const string ValidationException401 = "Registration validation Api return a status of 401 (Unauthorized access).";
     }
 }

--- a/server/StrDss.Data/Entities/DssDbContext.cs
+++ b/server/StrDss.Data/Entities/DssDbContext.cs
@@ -1243,6 +1243,7 @@ public partial class DssDbContext : DbContext
                 .ToView("dss_rental_upload_history_view");
 
             entity.Property(e => e.Errors).HasColumnName("errors");
+            entity.Property(e => e.RegistrationErrors).HasColumnName("registration_errors");
             entity.Property(e => e.FamilyNm)
                 .HasMaxLength(25)
                 .HasColumnName("family_nm");
@@ -1256,7 +1257,9 @@ public partial class DssDbContext : DbContext
             entity.Property(e => e.ProvidingOrganizationId).HasColumnName("providing_organization_id");
             entity.Property(e => e.ReportPeriodYm).HasColumnName("report_period_ym");
             entity.Property(e => e.Status).HasColumnName("status");
+            entity.Property(e => e.RegistrationStatus).HasColumnName("registration_status");
             entity.Property(e => e.Success).HasColumnName("success");
+            entity.Property(e => e.RegistrationSuccess).HasColumnName("registration_success");
             entity.Property(e => e.Total).HasColumnName("total");
             entity.Property(e => e.UpdDtm).HasColumnName("upd_dtm");
             entity.Property(e => e.UploadDeliveryId).HasColumnName("upload_delivery_id");
@@ -1320,6 +1323,21 @@ public partial class DssDbContext : DbContext
                 .HasComment("The number of lines in the uploaded file that were processed")
                 .HasColumnName("upload_lines_processed");
 
+            entity.Property(e => e.RegistrationStatus)
+                .HasMaxLength(20)
+                .HasComment("The current processing status of the registration validation: Pending, Processed, or Failed")
+                .HasColumnName("registration_status");
+            entity.Property(e => e.RegistrationLinesSuccess)
+                .HasComment("The number of lines in the uploaded file that successfully validated the registration number")
+                .HasColumnName("registration_lines_success");
+            entity.Property(e => e.RegistrationLinesError)
+                .HasComment("The number of lines in the uploaded file that failed to validate the registration number")
+                .HasColumnName("registration_lines_error");
+
+            entity.Property(e => e.UploadUserGuid)
+                .HasComment("The globally unique identifier (assigned by the identity provider) for the user who uploaded the file")
+                .HasColumnName("upload_user_guid");
+
             entity.HasOne(d => d.ProvidingOrganization).WithMany(p => p.DssUploadDeliveries)
                 .HasForeignKey(d => d.ProvidingOrganizationId)
                 .OnDelete(DeleteBehavior.ClientSetNull)
@@ -1344,6 +1362,10 @@ public partial class DssDbContext : DbContext
                 .HasMaxLength(32000)
                 .HasComment("Freeform description of the problem found while attempting to interpret the report line")
                 .HasColumnName("error_txt");
+            entity.Property(e => e.RegistrationTxt)
+                .HasMaxLength(32000)
+                .HasComment("Freeform description of the problem found while attempting to validate the reg no, or determine if the property is straa exempt")
+                .HasColumnName("registration_text");
             entity.Property(e => e.IncludingUploadDeliveryId)
                 .HasComment("Foreign key")
                 .HasColumnName("including_upload_delivery_id");
@@ -1356,6 +1378,9 @@ public partial class DssDbContext : DbContext
             entity.Property(e => e.IsValidationFailure)
                 .HasComment("Indicates that there has been a validation problem that prevents successful ingestion of the upload line")
                 .HasColumnName("is_validation_failure");
+            entity.Property(e => e.IsRegistrationFailure)
+                .HasComment("Indicates that there has been a problem validating the reg no, or determining if the property is straa exempt")
+                .HasColumnName("is_registration_failure");
             entity.Property(e => e.SourceLineTxt)
                 .HasMaxLength(32000)
                 .HasComment("Full text of the upload line")

--- a/server/StrDss.Data/Entities/DssRentalUploadHistoryView.cs
+++ b/server/StrDss.Data/Entities/DssRentalUploadHistoryView.cs
@@ -27,7 +27,13 @@ public partial class DssRentalUploadHistoryView
 
     public long? Errors { get; set; }
 
+    public long? RegistrationErrors { get; set; }
+
     public long? Success { get; set; }
 
+    public long? RegistrationSuccess { get; set; }
+
     public string? Status { get; set; }
+
+    public string? RegistrationStatus { get; set; }
 }

--- a/server/StrDss.Data/Entities/DssUploadDelivery.cs
+++ b/server/StrDss.Data/Entities/DssUploadDelivery.cs
@@ -64,6 +64,27 @@ public partial class DssUploadDelivery
     public int UploadLinesProcessed { get; set; }
 
     /// <summary>
+    /// The current processing status of the uploaded file: Pending, Processed, or Failed
+    /// </summary>
+    public string RegistrationStatus { get; set; } = null;
+
+
+    /// <summary>
+    /// The current processing status of the registration validation: Pending, Processed, or Failed
+    /// </summary>
+    public int RegistrationLinesSuccess { get; set; }
+
+    /// <summary>
+    /// The number of lines in the uploaded file that failed to validate the registration number
+    /// </summary>
+    public int RegistrationLinesError { get; set; }
+
+    /// <summary>
+    /// The globally unique identifier (assigned by the identity provider) for the user who uploaded the file
+    /// </summary>
+    public Guid? UploadUserGuid { get; set; }
+
+    /// <summary>
     /// Trigger-updated timestamp of last change
     /// </summary>
     public DateTime UpdDtm { get; set; }

--- a/server/StrDss.Data/Entities/DssUploadLine.cs
+++ b/server/StrDss.Data/Entities/DssUploadLine.cs
@@ -24,6 +24,11 @@ public partial class DssUploadLine
     public bool IsSystemFailure { get; set; }
 
     /// <summary>
+    /// Indicates that there has been a problem validating the reg no, or determining if the property is straa exempt
+    /// </summary>
+    public bool IsRegistrationFailure { get; set; }
+
+    /// <summary>
     /// An immutable system code identifying the organization who created the information in the upload line (e.g. AIRBNB)
     /// </summary>
     public string SourceOrganizationCd { get; set; } = null!;
@@ -42,6 +47,11 @@ public partial class DssUploadLine
     /// Freeform description of the problem found while attempting to interpret the report line
     /// </summary>
     public string? ErrorTxt { get; set; }
+
+    /// <summary>
+    /// Freeform description of the problem found while attempting to validate the reg no, or determine if the property is straa exempt
+    /// </summary>
+    public string? RegistrationTxt { get; set; }
 
     /// <summary>
     /// Foreign key

--- a/server/StrDss.Service/HttpClients/ServiceCollectionExtension.cs
+++ b/server/StrDss.Service/HttpClients/ServiceCollectionExtension.cs
@@ -46,7 +46,7 @@ namespace StrDss.Service.HttpClients
                 var apiKey = config.GetValue<string>("REGISTRATION_API_KEY") ?? "";
 
                 client.BaseAddress = new Uri(baseAddress);
-                client.Timeout = new TimeSpan(0, 10, 0);
+                client.Timeout = new TimeSpan(0, 2, 0);
                 client.DefaultRequestHeaders.Clear();
                 client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 client.DefaultRequestHeaders.Add("x-apikey", apiKey);

--- a/server/StrDss.Service/RegistrationService.cs
+++ b/server/StrDss.Service/RegistrationService.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using CsvHelper;
+using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -11,8 +12,11 @@ using StrDss.Model;
 using StrDss.Model.RentalReportDtos;
 using StrDss.Service.CsvHelpers;
 using StrDss.Service.EmailTemplates;
+using StrDss.Service.HttpClients;
 using System.Diagnostics;
 using System.Text;
+using NetTopologySuite.Geometries;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace StrDss.Service
 {
@@ -106,15 +110,18 @@ namespace StrDss.Service
             }
 
             // Update the upload with the status and counts
-            //upload.UploadStatus = errorCount > 0 ? UploadStatus.Failed : UploadStatus.Processed;
-            //upload.UploadLinesTotal = lineCount;
-            //upload.UploadLinesProcessed = processedCount;
-            //upload.UploadLinesSuccess = processedCount - errorCount;
-            //upload.UploadLinesError = errorCount;
-            //_unitOfWork.Commit();
+            upload.UploadStatus = errorCount > 0 ? UploadStatus.Failed : UploadStatus.Processed;
+            upload.RegistrationStatus = errorCount > 0 ? UploadStatus.Failed : UploadStatus.Processed;
+            upload.UploadLinesTotal = lineCount;
+            upload.UploadLinesProcessed = processedCount;
+            upload.UploadLinesSuccess = processedCount - errorCount;
+            upload.UploadLinesError = errorCount;
+            upload.RegistrationLinesSuccess = processedCount - errorCount;
+            upload.RegistrationLinesError = errorCount;
+            _unitOfWork.Commit();
 
-            if (upload.UpdUserGuid == null) return;
-            var user = await _userRepo.GetUserByGuid((Guid)upload.UpdUserGuid!);
+            if (upload.UploadUserGuid == null) return;
+            var user = await _userRepo.GetUserByGuid((Guid)upload.UploadUserGuid!);
             if (user == null) return;
 
 
@@ -166,49 +173,64 @@ namespace StrDss.Service
 
         private async Task<bool> ProcessUploadLine(DssUploadDelivery upload, long OrgId, DssUploadLine uploadLine, RegistrationDataRowUntyped row, bool isLastLine)
         {
-            var rowErrors = new Dictionary<string, List<string>>();
-
-            _validator.Validate(Entities.RegistrationDataRowUntyped, row, rowErrors);
-            if (rowErrors.Count > 0)
+            // Does this upload line meet the validation rules
+            var errors = new Dictionary<string, List<string>>();
+            _validator.Validate(Entities.RegistrationDataRowUntyped, row, errors);
+            if (errors.Count > 0)
             {
-                SaveUploadLine(uploadLine, rowErrors, true, false);
+                SaveUploadLine(uploadLine, errors.ParseErrorWithUnderScoredKeyName(), true);
                 return false;
             }
 
-            (bool isValid, Dictionary<string, List<string>> regErrors) = await _permitValidation.ValidateRegistrationPermitAsync(row.RegNo, row.RentalUnit, row.RentalStreet, row.RentalPostal);
-            if (isValid)
+            bool isValid = false;
+            string registrationTxt = "";
+            if (!string.IsNullOrEmpty(row.RegNo))
             {
-                if (!string.IsNullOrEmpty(row.ListingId))
+                // There is a reg no present, so we need to validate it
+                (isValid, registrationTxt) = await _permitValidation.ValidateRegistrationPermitAsync(row.RegNo, row.RentalUnit, row.RentalStreet, row.RentalPostal);
+                if (isValid)
                 {
-                    var listing = await _reportRepo.GetMasterListingAsync(OrgId, row.ListingId);
-                    if (listing != null)
+                    if (!string.IsNullOrEmpty(row.ListingId))
                     {
-                        using var tran = _unitOfWork.BeginTransaction();
-                        // Set the registration value here
-                        listing.BcRegistryNo = row.RegNo;
-
-                        var physicalAddress = await _addressRepo.GetPhysicalAdderssFromMasterListingAsync(listing.OfferingOrganizationId, listing.PlatformListingNo, row.RentalAddress);
-                        if (physicalAddress != null)
+                        var listing = await _reportRepo.GetMasterListingAsync(OrgId, row.ListingId);
+                        if (listing != null)
                         {
-                            // Set the unit, street, and postal code values here
-                            physicalAddress.RegRentalUnitNo = row.RentalUnit;
-                            physicalAddress.RegRentalStreetNo = row.RentalStreet;
-                            physicalAddress.RegRentalPostalCode = row.RentalPostal;                            
+                            using var tran = _unitOfWork.BeginTransaction();
+                            // Set the registration value here
+                            listing.BcRegistryNo = row.RegNo;
+
+                            var physicalAddress = await _addressRepo.GetPhysicalAdderssFromMasterListingAsync(listing.OfferingOrganizationId, listing.PlatformListingNo, row.RentalAddress);
+                            if (physicalAddress != null)
+                            {
+                                // Set the unit, street, and postal code values here
+                                physicalAddress.RegRentalUnitNo = row.RentalUnit;
+                                physicalAddress.RegRentalStreetNo = row.RentalStreet;
+                                physicalAddress.RegRentalPostalCode = row.RentalPostal;
+                            }
+                            tran.Commit();
                         }
-                        tran.Commit();
                     }
-                }                
+                }
+            }
+            else if (!string.IsNullOrEmpty(row.RentalAddress)) // We have an address, so we need to determine if the property is in an exempt jurisdiction
+            {
+                (isValid, registrationTxt) = await _permitValidation.CheckStraaExemptionStatus(row.RentalAddress);
+             }
+            else
+            {
+                // We shouldn't ever hit here, but here we are.
+                isValid = false;
+                registrationTxt = RegistrationValidationText.DataInvalid;
             }
 
-            SaveUploadLine(uploadLine, regErrors, false, !isValid, false);
+            SaveUploadLine(uploadLine, registrationTxt, !isValid);
             return isValid;
         }
 
-        private void SaveUploadLine(DssUploadLine uploadLine, Dictionary<string, List<string>> errors, bool isValidationFailure, bool isSystemError, bool useUnderscores = true)
+        private void SaveUploadLine(DssUploadLine uploadLine, string registrationTxt, bool isRegistrationFailure)
         {
-            uploadLine.IsValidationFailure = isValidationFailure;
-            uploadLine.IsSystemFailure = isSystemError;
-            uploadLine.ErrorTxt = useUnderscores ? errors.ParseErrorWithUnderScoredKeyName() : errors.ParseError();
+            uploadLine.IsRegistrationFailure = isRegistrationFailure;
+            uploadLine.RegistrationTxt = registrationTxt;
             uploadLine.IsProcessed = true;
             _unitOfWork.Commit();
         }

--- a/server/StrDss.Service/RegistrationValidationRule.cs
+++ b/server/StrDss.Service/RegistrationValidationRule.cs
@@ -11,8 +11,7 @@ namespace StrDss.Service
                 EntityName = Entities.RegistrationDataRowUntyped,
                 FieldName = RegistrationValidationFields.RptPeriod,
                 FieldType = FieldTypes.String,
-                Required = false,
-                RegexInfo = RegexDefs.GetRegexInfo(RegexDefs.YearMonth)
+                Required = false
             });
 
             rules.Add(new FieldValidationRule
@@ -29,8 +28,7 @@ namespace StrDss.Service
                 EntityName = Entities.RegistrationDataRowUntyped,
                 FieldName = RegistrationValidationFields.ListingId,
                 FieldType = FieldTypes.String,
-                Required = false,
-                MaxLength = 25,
+                Required = false
             });
 
             rules.Add(new FieldValidationRule
@@ -65,7 +63,7 @@ namespace StrDss.Service
                 EntityName = Entities.RegistrationDataRowUntyped,
                 FieldName = RegistrationValidationFields.BcRegNo,
                 FieldType = FieldTypes.String,
-                Required = true,
+                Required = false,
                 MaxLength = 25
             });
 
@@ -83,7 +81,7 @@ namespace StrDss.Service
                 EntityName = Entities.RegistrationDataRowUntyped,
                 FieldName = RegistrationValidationFields.RentalStreet,
                 FieldType = FieldTypes.String,
-                Required = true,
+                Required = false,
                 MaxLength = 25
             });
 


### PR DESCRIPTION
Added in all the workflows for STRAA Exemption checking
Added new fields to DSS_UPLOAD_DELIVERY table to hold status and counts for both rental listing report and registration validation
Updated the dss_rental_upload_history_view to use the delivery upload fields rather than calculated
Updated the dss_rental_upload_history_view to also have the status and counts for registration validation
Added an upload_user_guid field to the delivery upload table
Altered the join in dss_rental_upload_history_view to use the upload_user_guid field rather than the audit field of upd_user_guid
