### PR TITLE
Upload Stats

### DIFF
--- a/server/StrDss.Service/BizLicenceService.cs
+++ b/server/StrDss.Service/BizLicenceService.cs
@@ -85,8 +85,8 @@ namespace StrDss.Service
 
         private async Task ProcessBizLicenceUploadSubAsync(DssUploadDelivery upload)
         {
-            var count = 0;
-
+            var processedCount = 0;
+            var errorCount = 0;
             var header = upload.SourceHeaderTxt ?? "";
 
             var linesToProcess = await _uploadRepo.GetUploadLinesToProcessAsync(upload.UploadDeliveryId);
@@ -95,8 +95,6 @@ namespace StrDss.Service
             foreach (var lineToProcess in linesToProcess)
             {
                 var uploadLine = await _uploadRepo.GetUploadLineAsync(upload.UploadDeliveryId, lineToProcess.OrgCd, lineToProcess.SourceRecordNo);
-
-                count++;
                 var errors = new Dictionary<string, List<string>>();
                 var csvConfig = CsvHelperUtils.GetConfig(errors, false);
 
@@ -105,7 +103,19 @@ namespace StrDss.Service
                 var csvReader = new CsvReader(textReader, csvConfig);
 
                 var (orgCd, sourceRecordNo) = await ProcessLine(upload, header, uploadLine, csvReader);
-            }
+                processedCount++;
+                if (uploadLine.IsValidationFailure == true || uploadLine.IsSystemFailure == true) errorCount++;
+             }
+
+            upload.UploadStatus = errorCount > 0 ? UploadStatus.Failed : UploadStatus.Processed;
+            upload.RegistrationStatus = UploadStatus.Processed;
+            upload.UploadLinesTotal = lineCount;
+            upload.UploadLinesProcessed = processedCount;
+            upload.UploadLinesSuccess = processedCount - errorCount;
+            upload.UploadLinesError = errorCount;
+            upload.RegistrationLinesSuccess = 0;
+            upload.RegistrationLinesError = 0;
+            _unitOfWork.Commit();
         }
 
         private async Task<(string orgCd, string sourceRecordNo)> ProcessLine(DssUploadDelivery upload, string header, DssUploadLine line, CsvReader csvReader)

--- a/server/StrDss.Service/HttpClients/ServiceCollectionExtension.cs
+++ b/server/StrDss.Service/HttpClients/ServiceCollectionExtension.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http.Headers;
+using System.Net.Http.Headers;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
Added saving upload stats to the BuisnessLicense upload and Takedown upload.  Cleaned up the RentalListing Upload and added back in processing only 500 lines per job.
