### PR TITLE
Fix 200 Not Active

### DIFF
--- a/server/StrDss.Service/PermitValidationService.cs
+++ b/server/StrDss.Service/PermitValidationService.cs
@@ -86,7 +86,7 @@ public class PermitValidationService : IPermitValidationService
             else
             {
                 _logger.LogInformation("Permit status is: ." + resp.Status);
-
+                isValid = string.Compare(resp.Status, "ACTIVE", StringComparison.OrdinalIgnoreCase) == 0;
                 registrationText = "200:"+resp.Status;
             }
         }


### PR DESCRIPTION
Setting isValid to false when a 200 is returned but the status of the permit is not "ACTIVE".
