### PR TITLE
DSS-1309

### DIFF
--- a/server/StrDss.Model/CurrentUser.cs
+++ b/server/StrDss.Model/CurrentUser.cs
@@ -107,8 +107,6 @@ namespace StrDss.Model
             var clientId = user.GetCustomClaim(StrDssClaimTypes.ClientId);
             if (string.IsNullOrEmpty(clientId))
                 clientId = user.GetCustomClaim(StrDssClaimTypes.Azp);
-            if (string.IsNullOrEmpty(clientId))
-                clientId = user.GetCustomClaim(StrDssClaimTypes.Sub);
 
             DisplayName = clientId;
         }


### PR DESCRIPTION
Removed the 'sub' pull for display name from the claim to avoid potentially pulling inaccurate data.
